### PR TITLE
fix: decreased view width for mobile

### DIFF
--- a/src/components/screens/CareClientScreen.tsx
+++ b/src/components/screens/CareClientScreen.tsx
@@ -110,7 +110,7 @@ export const CareClientScreen = () => {
     }, []);
 
     return (
-        <Stack spacing={2} width={600}>
+        <Stack spacing={2} width={340}>
             <FormControl>
                 <InputLabel id="care-client-select-label">Care Client</InputLabel>
                 <Select

--- a/src/utilities/mapScheduleEntry.tsx
+++ b/src/utilities/mapScheduleEntry.tsx
@@ -4,7 +4,7 @@ export const mapScheduleEntry = (entry: ScheduleEntry, i: number) => {
     const formattedStartTime = entry.startDate.format('h:mm A');
     const formattedEndTime = entry.endDate.format('h:mm A');
     return (
-        <p key={i}>
+        <p key={i} style={{ textAlign: 'left' }}>
             {entry.startDate.format('MMMM D, YYYY')} from {formattedStartTime} to {formattedEndTime}
         </p>
     );


### PR DESCRIPTION
an absolute width was a time-based trade-off for responsive breakpoints (which is always a better option)